### PR TITLE
Quick `composite` function typo fix

### DIFF
--- a/src/vips/image.cr
+++ b/src/vips/image.cr
@@ -793,7 +793,7 @@ module Vips
     def composite(images : Array(Image), modes : Array(Enums::BlendMode), **kwargs)
       options = Optional.new(**kwargs)
 
-      Operation.call("composite", options, images.unshift(self), mode).as(Type).as_image
+      Operation.call("composite", options, images.unshift(self), modes).as(Type).as_image
     end
 
     # A synonym for `composite2`


### PR DESCRIPTION
In `Vips::Image.composite`, `modes` is misspelled as `mode`:
```crystal
def composite(images : Array(Image), modes : Array(Enums::BlendMode), **kwargs)
  options = Optional.new(**kwargs)

  Operation.call("composite", options, images.unshift(self), modes).as(Type).as_image
end
```
Changing `mode` to `modes` makes it work completely fine, so I've gone ahead and done so:
```diff
- Operation.call("composite", options, images.unshift(self), mode).as(Type).as_image
+ Operation.call("composite", options, images.unshift(self), modes).as(Type).as_image
```