### PR TITLE
Fix enum usage after refactor

### DIFF
--- a/src/vips/gobject.cr
+++ b/src/vips/gobject.cr
@@ -20,7 +20,7 @@ module Vips
         callback.pointer,
         data,
         nil,
-        LibVips::GConnectFlags::GConnectAfter).tap do |ret|
+        LibVips::GConnectFlags::After).tap do |ret|
         raise VipsException.new("Couldn't connect signal #{signal}") if ret == 0
       end
     end


### PR DESCRIPTION
Fixes reference to `LibVips::GConnectFlags::GConnectAfter` to `LibVips::GConnectFlags::After`.

This ought to have been caught by the Github workflow, but apparently not, the [commit history](https://github.com/naqvis/crystal-vips/commits/main/) shows that only the other workflow has been run.

The [workflow log](https://github.com/naqvis/crystal-vips/actions/workflows/ci.yml) tells us that the scheduled running has been disabled due to inactivity, but that shouldn't disable the workflow entirely on main.

Running the specs locally, I get a segfault, but I'll create a separate issue for that (it was what caused me to upgrade in the first place).