### PR TITLE
Fix Crystal version requirement

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -7,6 +7,6 @@ authors:
 description: |
   Crystal bindings for the libvips image processing library.
 
-crystal: ~> 0.36.0
+crystal: '>= 0.36.0'
 
 license: MIT


### PR DESCRIPTION
Fix Crystal version requirement so that shards doesn't warn with `Shard "vips" may be incompatible with Crystal 1.11.2`.